### PR TITLE
feat(config): adjust next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,6 @@
 // @ts-check
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  trailingSlash: true,
-  // output: 'export',
 };
 
 export default nextConfig;

--- a/src/components/life/life-sidebar.tsx
+++ b/src/components/life/life-sidebar.tsx
@@ -9,8 +9,7 @@ interface SidebarProps {
 
 export const Sidebar = ({ optionValue }: SidebarProps) => {
   const choices = optionValue.choices;
-  // To slice out the tailing '/'
-  const pathname = usePathname().slice(0, -1);
+  const pathname = usePathname();
   const selected = choices.find(({ value }) => value === pathname)?.description;
 
   if (!selected) {


### PR DESCRIPTION
Remove `output: export` since we have no choice (`quiz` and `article` pages are dynamic)

Remove trailing slash since it's ugly (complaints are welcome)